### PR TITLE
BUG FIX: delete method

### DIFF
--- a/tornadoasyncmemcache.py
+++ b/tornadoasyncmemcache.py
@@ -250,7 +250,7 @@ class Client(object):
         if not server:
             self.finish(partial(callback,0))
         self._statlog('delete')
-        if time != None:
+        if time:
             cmd = "delete %s %d" % (key, time)
         else:
             cmd = "delete %s" % key


### PR DESCRIPTION
When not have the time parmeter in delete method, 'time != None' may return
false, and that were not correct

```
modified:   tornadoasyncmemcache.py
```
