### PR TITLE
get rid of warning messages due trailing newline

### DIFF
--- a/tornadoasyncmemcache.py
+++ b/tornadoasyncmemcache.py
@@ -546,7 +546,7 @@ class _Host:
         self.readline(partial(self._expect_cb, text=text, callback=callback))
         
     def _expect_cb(self, data, text, callback):
-        if data != text:
+        if data.rstrip() != text:
             self.debuglog("while expecting '%s', got unexpected response '%s'" % (text, data))
         callback(data)
     


### PR DESCRIPTION
Simple change, but 'data' has a trailing newline (at least on my environment: memcached 1.4.5 on MacOS X) and the logs get pretty noisy.
